### PR TITLE
[RSDK-9931] Let the config have an optional maximum bounding box

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ To transform your camera into a motion detecting camera, configure this vision s
 
 Start by [configuring a camera](https://docs.viam.com/components/camera/webcam/) on your robot. Remember the name you give to the camera, it will be important later.
 
-> [!NOTE]  
+> [!NOTE]
 > Before configuring your camera or vision service, you must [create a robot](https://docs.viam.com/manage/fleet/robots/#add-a-new-robot).
 
 ## Configuration
 
 Navigate to the **Config** tab of your robot’s page in [the Viam app](https://app.viam.com/). Click on the **Services** subtab and click **Create service**. Select the `vision` type, then select the `motion-detector` model. Enter a name for your service and click **Create**.
 
-On the new component panel, copy and paste the following attribute template into your base’s **Attributes** box. 
+On the new component panel, copy and paste the following attribute template into your base’s **Attributes** box.
 ```json
 {
   "cam_name": "myCam",
@@ -26,7 +26,7 @@ On the new component panel, copy and paste the following attribute template into
 
 Edit the attributes as applicable.
 
-> [!NOTE]  
+> [!NOTE]
 > For more information, see [Configure a Robot](https://docs.viam.com/manage/configuration/).
 
 ### Attributes
@@ -70,7 +70,7 @@ The following attributes are available for `viam:vision:motion-detector` vision 
 
 ### Usage
 
-This module is made for use with the following methods of the [vision service API](https://docs.viam.com/services/vision/#api): 
+This module is made for use with the following methods of the [vision service API](https://docs.viam.com/services/vision/#api):
 - [`GetClassifications()`](https://docs.viam.com/services/vision/#getclassifications)
 - [`GetClassificationsFromCamera()`](https://docs.viam.com/services/vision/#getclassificationsfromcamera)
 - [`GetDetections()`](https://docs.viam.com/services/vision/#getdetections)
@@ -79,13 +79,13 @@ This module is made for use with the following methods of the [vision service AP
 
 The module behavior differs slightly for classifications and detections.
 
-When returning classifications, the module will always return a single classification with the `class_name` "motion". 
+When returning classifications, the module will always return a single classification with the `class_name` "motion".
 The `confidence` of the classification will be a percentage equal to the percentage of the image that moved (more than a threshold determined by the sensitivity attribute).
 
-When returning detections, the module will return a list of detections with bounding boxes that encapsulate the movement. 
-The `class_name` will be "motion" and the `confidence` will always be 0.5. 
+When returning detections, the module will return a list of detections with bounding boxes that encapsulate the movement.
+The `class_name` will be "motion" and the `confidence` will always be 0.5.
 
-## Visualize 
+## Visualize
 
 Once the `viam:vision:motion-detector` modular service is in use, configure a [transform camera](https://docs.viam.com/components/camera/transform/) to see classifications or detections appear in your robot's field of vision.
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ fi
 python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 
 if command -v apt-get; then
-    $SUDO apt-get -y install python3-venv 
+    $SUDO apt-get -y install python3-venv
     if dpkg -l python3-venv; then
         echo "python3-venv is installed, skipping setup"
     else

--- a/meta.json
+++ b/meta.json
@@ -10,10 +10,10 @@
       }
     ],
     "build": {
-      "setup": "make setup", 
+      "setup": "make setup",
       "build": "make dist/archive.tar.gz",
-      "path": "dist/archive.tar.gz", 
-      "arch": ["linux/amd64", "linux/arm64"] 
+      "path": "dist/archive.tar.gz",
+      "arch": ["linux/amd64", "linux/arm64"]
   },
   "entrypoint": "dist/main"
-  }
+}

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -64,6 +64,9 @@ class MotionDetector(Vision, Reconfigurable):
         sensitivity = config.attributes.fields["sensitivity"].number_value
         if sensitivity < 0 or sensitivity > 1:
             raise ValueError("Sensitivity should be a number between 0 and 1")
+        max_box_size = config.attributes.fields.get("max_box_size")
+        if max_box_size is not None and max_box_size.number_value <= 0:
+            raise ValueError("Maximum bounding box size, if present, must be a positive integer")
         return [source_cam]
 
     # Handles attribute reconfiguration

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -57,13 +57,13 @@ class MotionDetector(Vision, Reconfigurable):
     def validate_config(cls, config: ServiceConfig) -> Sequence[str]:
         source_cam = config.attributes.fields["cam_name"].string_value
         if source_cam == "":
-            raise Exception("Source camera must be provided as 'cam_name'")
+            raise ValueError("Source camera must be provided as 'cam_name'")
         min_boxsize = config.attributes.fields["min_box_size"].number_value
         if min_boxsize < 0:
-            raise Exception("Minimum bounding box size should be a positive integer")
+            raise ValueError("Minimum bounding box size should be a positive integer")
         sensitivity = config.attributes.fields["sensitivity"].number_value
         if sensitivity < 0 or sensitivity > 1:
-            raise Exception("Sensitivity should be a number between 0 and 1")
+            raise ValueError("Sensitivity should be a number between 0 and 1")
         return [source_cam]
 
     # Handles attribute reconfiguration
@@ -91,7 +91,7 @@ class MotionDetector(Vision, Reconfigurable):
         # Grab and grayscale 2 images
         input1 = await self.camera.get_image(mime_type=CameraMimeType.JPEG)
         if input1.mime_type not in [CameraMimeType.JPEG, CameraMimeType.PNG]:
-            raise Exception(
+            raise ValueError(
                 "image mime type must be PNG or JPEG, not ", input1.mime_type
             )
         img1 = pil.viam_to_pil_image(input1)
@@ -99,7 +99,7 @@ class MotionDetector(Vision, Reconfigurable):
 
         input2 = await self.camera.get_image()
         if input2.mime_type not in [CameraMimeType.JPEG, CameraMimeType.PNG]:
-            raise Exception(
+            raise ValueError(
                 "image mime type must be PNG or JPEG, not ", input2.mime_type
             )
         img2 = pil.viam_to_pil_image(input2)
@@ -117,7 +117,7 @@ class MotionDetector(Vision, Reconfigurable):
         **kwargs,
     ) -> List[Classification]:
         if camera_name != self.cam_name:
-            raise Exception(
+            raise ValueError(
                 "Camera name passed to method:",
                 camera_name,
                 "is not the configured 'cam_name'",
@@ -138,7 +138,7 @@ class MotionDetector(Vision, Reconfigurable):
         # Grab and grayscale 2 images
         input1 = await self.camera.get_image(mime_type=CameraMimeType.JPEG)
         if input1.mime_type not in [CameraMimeType.JPEG, CameraMimeType.PNG]:
-            raise Exception(
+            raise ValueError(
                 "image mime type must be PNG or JPEG, not ", input1.mime_type
             )
         img1 = pil.viam_to_pil_image(input1)
@@ -146,7 +146,7 @@ class MotionDetector(Vision, Reconfigurable):
 
         input2 = await self.camera.get_image()
         if input2.mime_type not in [CameraMimeType.JPEG, CameraMimeType.PNG]:
-            raise Exception(
+            raise ValueError(
                 "image mime type must be PNG or JPEG, not ", input2.mime_type
             )
         img2 = pil.viam_to_pil_image(input2)
@@ -163,7 +163,7 @@ class MotionDetector(Vision, Reconfigurable):
         **kwargs,
     ) -> List[Detection]:
         if camera_name != self.cam_name:
-            raise Exception(
+            raise ValueError(
                 "Camera name passed to method:",
                 camera_name,
                 "is not the configured 'cam_name':",
@@ -207,7 +207,7 @@ class MotionDetector(Vision, Reconfigurable):
     ) -> CaptureAllResult:
         result = CaptureAllResult()
         if camera_name not in (self.cam_name, ""):
-            raise Exception(
+            raise ValueError(
                 "Camera name passed to method:",
                 camera_name,
                 "is not the configured 'cam_name':",

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -287,6 +287,8 @@ class MotionDetector(Vision, Reconfigurable):
             area = (ymax - ymin) * (xmax - xmin)
             if area < self.min_box_size:
                 continue
+            if self.max_box_size is not None and area > self.max_box_size:
+                continue
 
             detections.append(
                 {

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -282,8 +282,10 @@ class MotionDetector(Vision, Reconfigurable):
             xs = [pt[0][0] for pt in c]
             ys = [pt[0][1] for pt in c]
             xmin, xmax, ymin, ymax = min(xs), max(xs), min(ys), max(ys)
+
             # Ignore this detection if it's the wrong size
-            if (ymax - ymin) * (xmax - xmin) < self.min_box_size:
+            area = (ymax - ymin) * (xmax - xmin)
+            if area < self.min_box_size:
                 continue
 
             detections.append(

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -282,17 +282,19 @@ class MotionDetector(Vision, Reconfigurable):
             xs = [pt[0][0] for pt in c]
             ys = [pt[0][1] for pt in c]
             xmin, xmax, ymin, ymax = min(xs), max(xs), min(ys), max(ys)
-            # Add to list of detections if big enough
-            if (ymax - ymin) * (xmax - xmin) > self.min_box_size:
-                detections.append(
-                    {
-                        "confidence": 0.5,
-                        "class_name": "motion",
-                        "x_min": int(xmin),
-                        "y_min": int(ymin),
-                        "x_max": int(xmax),
-                        "y_max": int(ymax),
-                    }
-                )
+            # Ignore this detection if it's the wrong size
+            if (ymax - ymin) * (xmax - xmin) < self.min_box_size:
+                continue
+
+            detections.append(
+                {
+                    "confidence": 0.5,
+                    "class_name": "motion",
+                    "x_min": int(xmin),
+                    "y_min": int(ymin),
+                    "x_max": int(xmax),
+                    "y_max": int(ymax),
+                }
+            )
 
         return detections

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -79,6 +79,9 @@ class MotionDetector(Vision, Reconfigurable):
         if self.sensitivity == 0:
             self.sensitivity = 0.9
         self.min_box_size = config.attributes.fields["min_box_size"].number_value
+        self.max_box_size = config.attributes.fields.get("max_box_size")
+        if self.max_box_size is not None:
+            self.max_box_size = self.max_box_size.number_value
 
     # This will be the main method implemented in this module.
     # Given a camera. Perform frame differencing and return how much of the image is moving

--- a/tests/fakecam.py
+++ b/tests/fakecam.py
@@ -18,14 +18,14 @@ class FakeCamera(Camera):
         self.images = [img1, img2]
 
     async def get_image(self, mime_type: str = "") -> Coroutine[Any, Any, ViamImage]:
-        self.count +=1 
+        self.count +=1
         return pil.pil_to_viam_image(self.images[self.count%2], CameraMimeType.JPEG)
-    
+
     async def get_images(self) -> Coroutine[Any, Any, Tuple[List[NamedImage] | ResponseMetadata]]:
         raise NotImplementedError
 
     async def get_properties(self) -> Coroutine[Any, Any, GetPropertiesResponse]:
         raise NotImplementedError
-    
+
     async def get_point_cloud(self) -> Coroutine[Any, Any, Tuple[bytes | str]]:
         raise NotImplementedError

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -83,7 +83,6 @@ class TestMotionDetector:
                                                 return_detections=True,
                                                 return_object_point_clouds=True)
         assert isinstance(out, CaptureAllResult)
-        print(out)
         assert out.image is not None
         assert out.classifications is not None
         assert len(out.classifications) == 1
@@ -102,7 +101,6 @@ class TestMotionDetector:
                                                 return_detections=True,
                                                 return_object_point_clouds=True)
         assert isinstance(out, CaptureAllResult)
-        print(out)
         assert out.image is not None
         assert out.classifications is not None
         assert len(out.classifications) == 1
@@ -121,7 +119,6 @@ class TestMotionDetector:
                                                 return_detections=True,
                                                 return_object_point_clouds=True)
         assert isinstance(out, CaptureAllResult)
-        print(out)
         assert out.image is not None
         assert out.classifications is not None
         assert len(out.classifications) == 1
@@ -138,7 +135,6 @@ class TestMotionDetector:
                                                 return_detections=True,
                                                 return_object_point_clouds=True)
         assert isinstance(out, CaptureAllResult)
-        print(out)
         assert out.image is not None
         assert out.classifications is not None
         assert len(out.classifications) == 1

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -25,6 +25,7 @@ class TestMotionDetector:
         md = MotionDetector("test")
         md.sensitivity = 0.9
         md.min_box_size = 1000
+        md.max_box_size = None
         md.cam_name = "test"
         md.camera = FakeCamera("test")
         return md

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -17,7 +17,6 @@ def make_component_config(dictionary: Mapping[str, Any]) -> ComponentConfig:
         struct.update(dictionary=dictionary)
         return ComponentConfig(attributes=struct)
 
-   
 
 
 class TestMotionDetector:
@@ -29,7 +28,7 @@ class TestMotionDetector:
         md.cam_name = "test"
         md.camera = FakeCamera("test")
         return md
-    
+
 
     def test_validate(self):
         md = self.getMD()
@@ -52,7 +51,7 @@ class TestMotionDetector:
         classifications = md.classification_from_gray_imgs(gray1, gray2)
         assert len(classifications) == 1
         assert classifications[0]["class_name"] == "motion"
-        
+
 
     def test_detections(self):
         img1 = Image.open("tests/img1.jpg")
@@ -74,23 +73,20 @@ class TestMotionDetector:
         assert props.detections_supported == True
         assert props.object_point_clouds_supported == False
 
-    
+
     @pytest.mark.asyncio
     async def test_captureall(self):
         md = self.getMD()
-        out = await md.capture_all_from_camera("test",return_image=True, 
+        out = await md.capture_all_from_camera("test",return_image=True,
                                                 return_classifications=True,
                                                 return_detections=True,
                                                 return_object_point_clouds=True)
         assert isinstance(out, CaptureAllResult)
         print(out)
-        assert out.image is not None 
-        assert out.classifications is not None 
+        assert out.image is not None
+        assert out.classifications is not None
         assert len(out.classifications) == 1
         assert out.classifications[0]["class_name"] == "motion"
-        assert out.detections is not None 
+        assert out.detections is not None
         assert out.detections[0]["class_name"] == "motion"
-        assert out.objects is None 
-
-
-
+        assert out.objects is None

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -21,7 +21,8 @@ def make_component_config(dictionary: Mapping[str, Any]) -> ComponentConfig:
 
 class TestMotionDetector:
 
-    def getMD(self):
+    @staticmethod
+    def getMD():
         md = MotionDetector("test")
         md.sensitivity = 0.9
         md.min_box_size = 1000

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -91,3 +91,56 @@ class TestMotionDetector:
         assert out.detections is not None
         assert out.detections[0]["class_name"] == "motion"
         assert out.objects is None
+
+
+    @pytest.mark.asyncio
+    async def test_captureall_not_too_large(self):
+        md = self.getMD()
+        md.max_box_size = 1000000000
+        out = await md.capture_all_from_camera("test",return_image=True,
+                                                return_classifications=True,
+                                                return_detections=True,
+                                                return_object_point_clouds=True)
+        assert isinstance(out, CaptureAllResult)
+        print(out)
+        assert out.image is not None
+        assert out.classifications is not None
+        assert len(out.classifications) == 1
+        assert out.classifications[0]["class_name"] == "motion"
+        assert out.detections is not None
+        assert out.detections[0]["class_name"] == "motion"
+        assert out.objects is None
+
+
+    @pytest.mark.asyncio
+    async def test_captureall_too_small(self):
+        md = self.getMD()
+        md.min_box_size = 1000000000
+        out = await md.capture_all_from_camera("test",return_image=True,
+                                                return_classifications=True,
+                                                return_detections=True,
+                                                return_object_point_clouds=True)
+        assert isinstance(out, CaptureAllResult)
+        print(out)
+        assert out.image is not None
+        assert out.classifications is not None
+        assert len(out.classifications) == 1
+        assert out.classifications[0]["class_name"] == "motion"
+        assert out.detections == []
+
+
+    @pytest.mark.asyncio
+    async def test_captureall_too_large(self):
+        md = self.getMD()
+        md.max_box_size = 5
+        out = await md.capture_all_from_camera("test",return_image=True,
+                                                return_classifications=True,
+                                                return_detections=True,
+                                                return_object_point_clouds=True)
+        assert isinstance(out, CaptureAllResult)
+        print(out)
+        assert out.image is not None
+        assert out.classifications is not None
+        assert len(out.classifications) == 1
+        assert out.classifications[0]["class_name"] == "motion"
+        assert out.detections == []

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -31,6 +31,19 @@ class TestMotionDetector:
         md.camera = FakeCamera("test")
         return md
 
+    @staticmethod
+    async def get_output(md):
+        out = await md.capture_all_from_camera("test",return_image=True,
+                                                return_classifications=True,
+                                                return_detections=True,
+                                                return_object_point_clouds=True)
+        assert isinstance(out, CaptureAllResult)
+        assert out.image is not None
+        assert out.classifications is not None
+        assert len(out.classifications) == 1
+        assert out.classifications[0]["class_name"] == "motion"
+        return out
+
 
     def test_validate(self):
         md = self.getMD()
@@ -79,15 +92,7 @@ class TestMotionDetector:
     @pytest.mark.asyncio
     async def test_captureall(self):
         md = self.getMD()
-        out = await md.capture_all_from_camera("test",return_image=True,
-                                                return_classifications=True,
-                                                return_detections=True,
-                                                return_object_point_clouds=True)
-        assert isinstance(out, CaptureAllResult)
-        assert out.image is not None
-        assert out.classifications is not None
-        assert len(out.classifications) == 1
-        assert out.classifications[0]["class_name"] == "motion"
+        out = await self.get_output(md)
         assert out.detections is not None
         assert out.detections[0]["class_name"] == "motion"
         assert out.objects is None
@@ -97,15 +102,7 @@ class TestMotionDetector:
     async def test_captureall_not_too_large(self):
         md = self.getMD()
         md.max_box_size = 1000000000
-        out = await md.capture_all_from_camera("test",return_image=True,
-                                                return_classifications=True,
-                                                return_detections=True,
-                                                return_object_point_clouds=True)
-        assert isinstance(out, CaptureAllResult)
-        assert out.image is not None
-        assert out.classifications is not None
-        assert len(out.classifications) == 1
-        assert out.classifications[0]["class_name"] == "motion"
+        out = await self.get_output(md)
         assert out.detections is not None
         assert out.detections[0]["class_name"] == "motion"
         assert out.objects is None
@@ -115,15 +112,7 @@ class TestMotionDetector:
     async def test_captureall_too_small(self):
         md = self.getMD()
         md.min_box_size = 1000000000
-        out = await md.capture_all_from_camera("test",return_image=True,
-                                                return_classifications=True,
-                                                return_detections=True,
-                                                return_object_point_clouds=True)
-        assert isinstance(out, CaptureAllResult)
-        assert out.image is not None
-        assert out.classifications is not None
-        assert len(out.classifications) == 1
-        assert out.classifications[0]["class_name"] == "motion"
+        out = await self.get_output(md)
         assert out.detections == []
 
 
@@ -131,13 +120,5 @@ class TestMotionDetector:
     async def test_captureall_too_large(self):
         md = self.getMD()
         md.max_box_size = 5
-        out = await md.capture_all_from_camera("test",return_image=True,
-                                                return_classifications=True,
-                                                return_detections=True,
-                                                return_object_point_clouds=True)
-        assert isinstance(out, CaptureAllResult)
-        assert out.image is not None
-        assert out.classifications is not None
-        assert len(out.classifications) == 1
-        assert out.classifications[0]["class_name"] == "motion"
+        out = await self.get_output(md)
         assert out.detections == []


### PR DESCRIPTION
The intention here is that if the camera provides a corrupted frame and everything suddenly goes gray for a moment, that shouldn't count as motion. This also means that if someone bumps the camera and the entire scene shifts to the left, that also shouldn't count as motion.

Tried on an Orin Nano: seems to work! edit: if I don't mention it in the config, the behavior seems unchanged, and if I do mention it, large bounding boxes do not appear, while small ones still do. I was unable to get a corrupted image, so can't ensure that those are no longer considered noise.

I've also made some other cleanup changes:
- Remove trailing whitespace. Ideally we'd never have any to begin with
- Don't raise raw `Exception`s, because the only way to catch them is to catch all exceptions. Instead, raise something specific (in these cases, I went with `ValueError`, but could be convinced of other types, too). 

My hope is that reviewing commit-by-commit is easy, and makes it clear why each change occurred.