### PR TITLE
[RSDK-9938] add inline description to meta.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ The following attributes are available for `viam:vision:motion-detector` vision 
 
 ```
 
+### Example Attributes
+
+You should be able to copy and paste this straight into the setup section, just change the camera name:
+
+```json
+{
+  "cam_name": "myCam",
+  "sensitivity": 0.9,
+  "min_box_size": 2000
+}
+```
+
 ### Usage
 
 This module is made for use with the following methods of the [vision service API](https://docs.viam.com/services/vision/#api):

--- a/meta.json
+++ b/meta.json
@@ -6,7 +6,9 @@
     "models": [
       {
         "api": "rdk:service:vision",
-        "model": "viam:vision:motion-detector"
+        "model": "viam:vision:motion-detector",
+        "markdown_link": "README.md#example-attributes",
+        "short_description": "A vision service that finds bounding boxes around motion"
       }
     ],
     "build": {


### PR DESCRIPTION
I'm not convinced I've done this right: I don't see any differences when trying this out locally. I doubt I'm running too old a version of `viam-server`: I've got 0.61.0, from two weeks ago. Maybe the changes are only visible once we deploy to the modular registry? Maybe I've done it wrong...

The example attributes are an excerpt from the "example configuration" section directly above it. We should have both: the configuration is super useful for getting everything up and going, and the attributes are useful if you've got everything up and you just want to see what it looked like before you fiddled with everything.

I don't like the comma I put in the readme, but couldn't figure out what other punctuation to put there. :shrug: 