### PR TITLE
[RSDK-10249] try to ensure that libGL is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # This first target is the one that runs by default.
 dist/archive.tar.gz: dist/main
-	tar -czvf dist/archive.tar.gz dist/main
+	tar -czvf dist/archive.tar.gz dist/main first_run.sh
 
 setup:
 	./setup.sh

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Start by [configuring a camera](https://docs.viam.com/components/camera/webcam/)
 > [!NOTE]
 > Before configuring your camera or vision service, you must [create a robot](https://docs.viam.com/manage/fleet/robots/#add-a-new-robot).
 
+> [!NOTE]
+> If you run this on a non-Debian-based flavor of Linux, you need to ensure that libGL.so.1 is installed on your system! It's probably already installed, unless you're using a headless setup. Ubuntu is Debian-based, so this note doesn't apply on Ubuntu.
+
 ## Configuration
 
 Navigate to the **Config** tab of your robot’s page in [the Viam app](https://app.viam.com/). Click on the **Services** subtab and click **Create service**. Select the `vision` type, then select the `motion-detector` model. Enter a name for your service and click **Create**.

--- a/first_run.sh
+++ b/first_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$(uname | cut -f 1 -d_)" == Linux ]; then
+	# We need libGL.so.1 installed on Linux. The given approach will work on Debian-based systems,
+	# such as Ubuntu. On non-Debian systems, it will fail, we will print the warning, and then hope
+	# that the user already has it installed (which is likely, but not guaranteed, especially on a
+	# headless setup).
+	apt-get install -y libgl1 || echo "Unable to install libGL.so.1. We hope it's already there..."
+fi

--- a/first_run.sh
+++ b/first_run.sh
@@ -5,5 +5,5 @@ if [ "$(uname | cut -f 1 -d_)" == Linux ]; then
 	# such as Ubuntu. On non-Debian systems, it will fail, we will print the warning, and then hope
 	# that the user already has it installed (which is likely, but not guaranteed, especially on a
 	# headless setup).
-	apt-get install -y libgl1 || echo "Unable to install libGL.so.1. We hope it's already there..."
+	apt-get update && apt-get install -y libgl1 || echo "Unable to install libGL.so.1. We hope it's already there..."
 fi

--- a/meta.json
+++ b/meta.json
@@ -17,5 +17,6 @@
       "path": "dist/archive.tar.gz",
       "arch": ["linux/amd64", "linux/arm64", "darwin/arm64"]
   },
-  "entrypoint": "dist/main"
+  "entrypoint": "dist/main",
+  "first_run": "first_run.sh"
 }


### PR DESCRIPTION
The issue @randhid had run into was that her Raspian Lite installation didn't include libGL.so.1, so the module couldn't load its libraries properly. 

I spent the morning fighting with PyInstaller to try to convince it to include that file in the binary it creates, and eventually gave up and wrote a first_run.sh instead.

I've tried out the first_run.sh script locally: it appears to work on Ubuntu. I've also ensured that `make dist/archive.tar.gz` packages everything up correctly. I haven't tried it in more detail, though.