### PR TITLE
[RDSK-10175]: Create default camera behavior for `*FromCamera methods`

### DIFF
--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -141,7 +141,9 @@ class MotionDetector(Vision, Reconfigurable):
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[Classification]:
-        if camera_name != self.cam_name:
+        if camera_name == "":
+            camera_name = self.cam_name
+        elif camera_name != self.cam_name:
             raise ValueError(
                 "Camera name passed to method:",
                 camera_name,
@@ -187,7 +189,9 @@ class MotionDetector(Vision, Reconfigurable):
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[Detection]:
-        if camera_name != self.cam_name:
+        if camera_name == "":
+            camera_name = self.cam_name
+        elif camera_name != self.cam_name:
             raise ValueError(
                 "Camera name passed to method:",
                 camera_name,

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -82,6 +82,12 @@ class TestConfigValidation:
         with pytest.raises(ValueError, match=error_message):
             response = md.validate_config(config=config)
 
+    def test_empty_config_name(self):
+        md = getMD()
+        raw_config = {"cam_name": ""}
+        config = make_component_config(raw_config)
+        with pytest.raises(ValueError, match="Source camera must be provided as 'cam_name'"):
+            response = md.validate_config(config=config)
 
 class TestMotionDetector:
     @staticmethod


### PR DESCRIPTION
## Changes
- [x] added logic to `GetDetectionsFromCamera` and `getClassificationsFromCamera` to switch to default camera if `camera_name` is not given.
- [x] write a test confirming that behavior

## Open Questions
1. Which vision services cannot use a default camera? (all I know if now is `getObjectPointClouds`)