### PR TITLE
Add `camera_name` as an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Navigate to the **Config** tab of your robot’s page in [the Viam app](https://
 On the new component panel, copy and paste the following attribute template into your base’s **Attributes** box.
 ```json
 {
-  "cam_name": "myCam",
+  "camera_name": "myCam",
   "sensitivity": 0.9,
   "min_box_size": 2000
 }
@@ -38,12 +38,16 @@ The following attributes are available for `viam:vision:motion-detector` vision 
 
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `cam_name` | string | **Required** | The name of the camera configured on your robot. |
+| `camera_name` | string | **Required** | The name of the camera configured on your robot. |
+| `cam_name` | string | **Required** | \*\***DEPRECATED**\*\* The name of the camera configured on your robot. |
 | `min_box_size` | int | **Optional** | The size (in square pixels) of the smallest bounding box to allow. Relevant for GetDetections/GetDetectionsFromCamera only. You must specify at most one of `min_box_size` and `min_box_percent`.
 | `min_box_percent` | int | **Optional** | The fraction of the image (between 0 and 1) that the smallest bounding box must cover. Relevant for GetDetections/GetDetectionsFromCamera only. You must specify at most one of `min_box_size` and `min_box_percent`.
 | `max_box_size` | int | **Optional** | The size (in square pixels) of the largest bounding box to allow. Relevant for GetDetections/GetDetectionsFromCamera only. You must specify at most one of `max_box_size` and `max_box_percent`.
 | `max_box_percent` | int | **Optional** | The fraction of the image (between 0 and 1) that the largest bounding box can cover. Relevant for GetDetections/GetDetectionsFromCamera only. You must specify at most one of `max_box_size` and `max_box_percent`.
 | `sensitivity` | float | **Optional** | A number from 0 - 1. Larger numbers will make the module more sensitive to motion. Default = 0.9 |
+
+> [!WARNING]  
+> Either one of `camera_name` or `cam_name` will be accepted, but not both. `camera_name` is preferred.
 
 ### Example Configuration
 
@@ -64,7 +68,7 @@ The following attributes are available for `viam:vision:motion-detector` vision 
       "namespace": "rdk",
       "model": "viam:vision:motion-detector",
       "attributes": {
-        "cam_name": "myCam",
+        "camera_name": "myCam",
         "sensitivity": 0.9,
         "min_box_size": 2000
       }
@@ -80,7 +84,7 @@ You should be able to copy and paste this straight into the setup section, just 
 
 ```json
 {
-  "cam_name": "myCam",
+  "camera_name": "myCam",
   "sensitivity": 0.9,
   "min_box_size": 2000
 }

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -106,6 +106,7 @@ class TestConfigValidation:
     @parameterized.expand((
         ("cam_name not defined, camera_name not defined", {}, pytest.source_camera_name_none_defined_error_message),
         ("cam_name defined, camera_name defined", {"camera_name": "test", "cam_name": "test"}, pytest.source_camera_name_both_defined_error_message),
+        ("cam_name empty, camera_name empty", {"cam_name": "", "camera_name": ""}, pytest.source_camera_name_none_defined_error_message),
     ))
     def test_invalid_camera_names(self, unused_test_name, cam_config, error_message):
         md = getMD()

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -13,6 +13,8 @@ import pytest
 import cv2
 import numpy as np
 
+pytest.source_camera_name_none_defined_error_message = "Source camera must be provided as 'cam_name' or 'camera_name', but neither was provided"
+pytest.source_camera_name_both_defined_error_message = "Source camera must be provided as 'cam_name' or 'camera_name', but both were provided"
 
 def make_component_config(dictionary: Mapping[str, Any]) -> ComponentConfig:
         struct = Struct()
@@ -36,7 +38,7 @@ class TestConfigValidation:
     def test_empty(self):
         md = getMD()
         empty_config = make_component_config({})
-        with pytest.raises(ValueError, match="Source camera must be provided as 'cam_name'"):
+        with pytest.raises(ValueError, match=pytest.source_camera_name_none_defined_error_message):
             response = md.validate_config(config=empty_config)
 
 
@@ -86,7 +88,29 @@ class TestConfigValidation:
         md = getMD()
         raw_config = {"cam_name": ""}
         config = make_component_config(raw_config)
-        with pytest.raises(ValueError, match="Source camera must be provided as 'cam_name'"):
+        with pytest.raises(ValueError, match=pytest.source_camera_name_none_defined_error_message):
+            response = md.validate_config(config=config)
+
+    # For each way to specify a valid camera name, test that the return is valid.
+    @parameterized.expand((
+        ("cam_name defined, camera_name not defined",  {"cam_name": "test"}),
+        ("camera_name defined, cam_name not defined",  {"camera_name": "test"}),
+    ))
+    def test_valid_camera_names(self, unused_test_name, cam_config):
+        md = getMD()
+        config = make_component_config(cam_config)
+        response = md.validate_config(config=config)
+        assert response == ["test"]
+
+    # For each way to spedify an invalid camera name, test that the expected error is raised.
+    @parameterized.expand((
+        ("cam_name not defined, camera_name not defined", {}, pytest.source_camera_name_none_defined_error_message),
+        ("cam_name defined, camera_name defined", {"camera_name": "test", "cam_name": "test"}, pytest.source_camera_name_both_defined_error_message),
+    ))
+    def test_invalid_camera_names(self, unused_test_name, cam_config, error_message):
+        md = getMD()
+        config = make_component_config(cam_config)
+        with pytest.raises(ValueError, match=error_message):
             response = md.validate_config(config=config)
 
 class TestMotionDetector:


### PR DESCRIPTION
## Changes
- [x] Add `camera_name` as attribute to motion detector
- [x] Validate that only one of `cam_name` and `camera_name` are populated
- [x] Use the attribute that is populated as the actual name
- [x] Write tests to confirm this behavior
- [x] update README to use `camera_name` and show that `cam_name` is deprecated 

- also tested locally and everything works as expected