### PR TITLE
More linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E0401,E1101,C0116,W0613,R0913,C0116,R0914,C0103,W0201,W0719 src/
+	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,W0613,R0913,C0116,R0914,C0103,W0201,W0719 src/
 

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,10 @@ test:
 dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
+# We disable the following checks:
+# C0114: module doesn't have a docstring
+# C0116: functions don't have docstrings
+# E1101: the linter can't figure out that the cv2 module has functions inside of it
+# W0201: attributes are defined outside of __init__
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,W0201 src/
+	. .venv/bin/activate && pylint --disable=C0114,C0116,E1101,W0201 src/

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,R0914,C0103,W0201 src/
+	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,C0103,W0201 src/

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,W0613,R0913,C0116,R0914,C0103,W0201,W0719 src/
+	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,R0913,C0116,R0914,C0103,W0201,W0719 src/
 

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,C0103,W0201 src/
+	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,W0201 src/

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,4 @@ dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,R0913,C0116,R0914,C0103,W0201,W0719 src/
-
+	. .venv/bin/activate && pylint --disable=C0114,E1101,R0913,C0116,R0914,C0103,W0201 src/

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ dist/main:
 	. .venv/bin/activate && python -m PyInstaller --onefile --hidden-import="googleapiclient" --add-data="./src:src" src/main.py
 
 lint:
-	. .venv/bin/activate && pylint --disable=C0114,E1101,R0913,C0116,R0914,C0103,W0201 src/
+	. .venv/bin/activate && pylint --disable=C0114,E1101,C0116,R0914,C0103,W0201 src/

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,8 @@ import asyncio
 from viam.services.vision import Vision
 from viam.module.module import Module
 from viam.resource.registry import Registry, ResourceCreatorRegistration
-from src.motion_detector import MotionDetector
+
+from motion_detector import MotionDetector
 
 
 async def main():

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -236,7 +236,8 @@ class MotionDetector(Vision, Reconfigurable):
         )
 
     # The linter doesn't like the vision service API, which we can't change.
-    async def capture_all_from_camera(  # pylint: disable=too-many-positional-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    async def capture_all_from_camera(
         self,
         camera_name: str,
         return_image: bool = False,

--- a/src/motion_detector.py
+++ b/src/motion_detector.py
@@ -124,7 +124,7 @@ class MotionDetector(Vision, Reconfigurable):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **kwargs,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> List[Classification]:
         # Grab and grayscale 2 images
         input1 = await self.camera.get_image(mime_type=CameraMimeType.JPEG)
@@ -152,7 +152,7 @@ class MotionDetector(Vision, Reconfigurable):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **kwargs,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> List[Classification]:
         if camera_name == "":
             camera_name = self.cam_name
@@ -173,7 +173,7 @@ class MotionDetector(Vision, Reconfigurable):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **kwargs,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> List[Detection]:
         # Grab and grayscale 2 images
         input1 = await self.camera.get_image(mime_type=CameraMimeType.JPEG)
@@ -200,7 +200,7 @@ class MotionDetector(Vision, Reconfigurable):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **kwargs,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> List[Detection]:
         if camera_name == "":
             camera_name = self.cam_name

--- a/tests/fakecam.py
+++ b/tests/fakecam.py
@@ -1,4 +1,4 @@
-from typing import Any, Coroutine, Final, List, Optional, Tuple, Dict
+from typing import Any, Coroutine, List, Tuple
 from viam.components.camera import Camera
 from viam.gen.component.camera.v1.camera_pb2 import GetPropertiesResponse
 from viam.media.video import NamedImage, ViamImage, CameraMimeType

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -37,7 +37,7 @@ class TestConfigValidation:
         md = getMD()
         empty_config = make_component_config({})
         with pytest.raises(ValueError, match=pytest.source_camera_name_none_defined_error_message):
-            response = md.validate_config(config=empty_config)
+            md.validate_config(config=empty_config)
 
 
     # For each way to specify a valid min/max size, have a test that checks it's valid.
@@ -80,14 +80,14 @@ class TestConfigValidation:
         raw_config.update(extra_config_values)
         config = make_component_config(raw_config)
         with pytest.raises(ValueError, match=error_message):
-            response = md.validate_config(config=config)
+            md.validate_config(config=config)
 
     def test_empty_config_name(self):
         md = getMD()
         raw_config = {"cam_name": ""}
         config = make_component_config(raw_config)
         with pytest.raises(ValueError, match=pytest.source_camera_name_none_defined_error_message):
-            response = md.validate_config(config=config)
+            md.validate_config(config=config)
 
     # For each way to specify a valid camera name, test that the return is valid.
     @parameterized.expand((
@@ -110,7 +110,7 @@ class TestConfigValidation:
         md = getMD()
         config = make_component_config(cam_config)
         with pytest.raises(ValueError, match=error_message):
-            response = md.validate_config(config=config)
+            md.validate_config(config=config)
 
 class TestMotionDetector:
     @staticmethod

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -1,12 +1,10 @@
 from src.motion_detector import MotionDetector
 from tests.fakecam import FakeCamera
 from PIL import Image
-from unittest.mock import MagicMock, patch
-from viam.components.camera import Camera
 from viam.proto.app.robot import ComponentConfig
 from google.protobuf.struct_pb2 import Struct
-from viam.services.vision import CaptureAllResult, Classification, Detection
-from typing import List, Mapping, Any
+from viam.services.vision import CaptureAllResult
+from typing import Mapping, Any
 
 from parameterized import parameterized
 import pytest

--- a/tests/test_motiondetector.py
+++ b/tests/test_motiondetector.py
@@ -155,9 +155,9 @@ class TestMotionDetector:
     async def test_properties(self):
         md = getMD()
         props = await md.get_properties()
-        assert props.classifications_supported == True
-        assert props.detections_supported == True
-        assert props.object_point_clouds_supported == False
+        assert props.classifications_supported
+        assert props.detections_supported
+        assert not props.object_point_clouds_supported
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
I wanted a break from "real" work, so I made this. 

No changes to behavior are intended! All tests still pass, including the linter. However, this time the linter has fewer exclusions (and more narrow exclusions).

I recommend reviewing commit-by-commit: most of them are trivial, but there's one in the middle where I split a complicated function into two simpler ones.

I also tried linting the tests, and got surprised that many things imported by the tests fail the lint checks! So, instead I ran `ruff check` and made sure that passed. Should that be added to the definition of `make lint`? I can argue either way. :shrug: 

I'm open to undoing the commit about removing unreferenced variables in the tests: although they're not used in the tests, it could be nice to see that `validate_config` has a return value. I can see arguments for both sides here, and will put it back the way it was if you want.

I haven't tested that this still works with an actual camera yet, will do that now...